### PR TITLE
Allow multiple env.factors and conditions

### DIFF
--- a/R/envGrowthChanges.R
+++ b/R/envGrowthChanges.R
@@ -23,9 +23,9 @@ envGrowthChanges = function(species, env.factors=2, conditions=2, strength, mode
       env.matrix[,i] = abs(rnorm(species, sd=strength))
     }
   }
-  features = matrix(nrow=2, ncol=2)
-  colnames(features) = c("feature1", "feature2")
-  rownames(features) = c("condition1", "condition2")
+  features = matrix(nrow=conditions, ncol=env.factors)
+  colnames(features) = paste("feature", c(1:env.factors), sep="_")
+  rownames(features) = paste("condition", c(1:conditions), sep="_")
   for (j in 1:conditions){
     env.state = rnorm(env.factors)
     if (mode == "abs"){


### PR DESCRIPTION
I changed line 26-28.
Before the number of `env.factors` and `conditions` was `fixed to 2`.
With the change the number of `env.factors` and `conditions` is `variable`,
which makes the function more general